### PR TITLE
Use ActionBarActivity and remove layout attr not supported on Android 2.x

### DIFF
--- a/app/src/main/java/com/michaelcarrano/detectivedroid/view/AppListActivity.java
+++ b/app/src/main/java/com/michaelcarrano/detectivedroid/view/AppListActivity.java
@@ -4,11 +4,11 @@ import com.michaelcarrano.detectivedroid.R;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v4.app.FragmentActivity;
+import android.support.v7.app.ActionBarActivity;
 import android.view.Menu;
 import android.view.MenuItem;
 
-public class AppListActivity extends FragmentActivity implements AppListFragment.Callbacks {
+public class AppListActivity extends ActionBarActivity implements AppListFragment.Callbacks {
 
     /**
      * Whether or not the activity is in two-pane mode, i.e. running on a tablet device.

--- a/app/src/main/java/com/michaelcarrano/detectivedroid/view/DetectorTaskFragment.java
+++ b/app/src/main/java/com/michaelcarrano/detectivedroid/view/DetectorTaskFragment.java
@@ -22,11 +22,11 @@ public class DetectorTaskFragment extends DialogFragment implements DetectorAsyn
 
     public static final int TASK_REQUEST_CODE = 0;
 
-    DetectorAsyncTask mDetectorTask;
+    private DetectorAsyncTask mDetectorTask;
 
-    ProgressBar mProgressBar;
+    private ProgressBar mProgressBar;
 
-    TextView mProgressText;
+    private TextView mProgressText;
 
     public void setTask(DetectorAsyncTask task) {
         mDetectorTask = task;

--- a/app/src/main/res/layout/list_item_card.xml
+++ b/app/src/main/res/layout/list_item_card.xml
@@ -2,7 +2,6 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?android:selectableItemBackground"
     android:descendantFocusability="blocksDescendants"
     android:paddingBottom="4dp"
     android:paddingLeft="12dp"


### PR DESCRIPTION
The ActionBar was not displayed on Android 2.x and the app also crashes when it tried to render the list_item_card layout due to using android:background="?android:selectableItemBackground" which isn't support on that version of Android.
