### PR TITLE
Perrmission changes for Android 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This makes it really easy to see what other developers/companies are using to de
 
 Detective Droid requires no permissions and works on Android API 21 (Android 5.0 Lollipop) and newer.
 
+- **Andriod 11**: Changes in Android 11 require a permission in order to get the list of apps installed on the user's device. You can read more about this change: [https://developer.android.com/preview/privacy/package-visibility](https://developer.android.com/preview/privacy/package-visibility)
+
 
 ## Limitations
 Detective Droid is unable to detect libraries that are obfuscated with Proguard/R8. Additionally, unable to detect libraries that are dynamically created. For instance, [LeadBolt](http://leadbolt.com) creates their SDK on the fly for each developer which means a unique Classpath.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.michaelcarrano.detectivedroid">
 
+    <uses-permission
+        android:name="android.permission.QUERY_ALL_PACKAGES"
+        tools:ignore="QueryAllPackagesPermission" />
+
     <application
         android:name=".DetectiveApplication"
         android:allowBackup="true"

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,9 @@ import com.michaelcarrano.detectivedroid.buildsrc.Versions
 
 buildscript {
     ext.buildConfig = [
-            'compileSdk': 29,
+            'compileSdk': 30,
             'minSdk'    : 21,
-            'targetSdk' : 29,
+            'targetSdk' : 30,
     ]
 
     repositories {

--- a/buildSrc/src/main/java/com/michaelcarrano/detectivedroid/buildsrc/dependencies.gradle.kt
+++ b/buildSrc/src/main/java/com/michaelcarrano/detectivedroid/buildsrc/dependencies.gradle.kt
@@ -5,7 +5,7 @@ object Versions {
 }
 
 object Libs {
-    const val androidGradlePlugin = "com.android.tools.build:gradle:4.2.0-alpha01"
+    const val androidGradlePlugin = "com.android.tools.build:gradle:4.2.0-alpha02"
     const val playPublisherPlugin = "com.github.triplet.gradle:play-publisher:2.6.1"
     const val jacoco = "org.jacoco:org.jacoco.core:0.8.5"
 


### PR DESCRIPTION
Android 11 requires a permission in order to retrieve the apps that are installed on the device.

Resolves #45 