### PR TITLE
Handle PackageManager returning null values

### DIFF
--- a/app/src/main/java/com/michaelcarrano/detectivedroid/data/model/AppEntity.kt
+++ b/app/src/main/java/com/michaelcarrano/detectivedroid/data/model/AppEntity.kt
@@ -1,8 +1,8 @@
 package com.michaelcarrano.detectivedroid.data.model
 
 data class AppEntity(
-    val name: String,
-    val packageName: String,
-    val versionName: String,
+    val name: String?,
+    val packageName: String?,
+    val versionName: String?,
     val userApp: Boolean
 )

--- a/app/src/main/java/com/michaelcarrano/detectivedroid/presentation/model/AppMapper.kt
+++ b/app/src/main/java/com/michaelcarrano/detectivedroid/presentation/model/AppMapper.kt
@@ -1,13 +1,18 @@
 package com.michaelcarrano.detectivedroid.presentation.model
 
+import android.content.res.Resources
 import com.michaelcarrano.detectivedroid.data.model.AppEntity
 import javax.inject.Inject
 
-class AppMapper @Inject constructor() : Mapper<AppUiModel, AppEntity> {
+class AppMapper @Inject constructor(
+    private val resources: Resources
+) : Mapper<AppUiModel, AppEntity> {
 
     override fun mapToUiModel(type: AppEntity) =
-        AppUiModel(type.name, type.packageName, type.versionName)
+        AppUiModel(value(type.name), value(type.packageName), value(type.versionName))
 
     override fun mapToUiModels(type: List<AppEntity>): List<AppUiModel> =
         type.map { mapToUiModel(it) }
+
+    private fun value(s: String?) = s ?: resources.getString(android.R.string.unknownName)
 }

--- a/app/src/test/java/com/michaelcarrano/detectivedroid/domain/GetAppListUseCaseTest.kt
+++ b/app/src/test/java/com/michaelcarrano/detectivedroid/domain/GetAppListUseCaseTest.kt
@@ -1,8 +1,10 @@
 package com.michaelcarrano.detectivedroid.domain
 
+import android.content.res.Resources
 import com.michaelcarrano.detectivedroid.data.AppRepository
 import com.michaelcarrano.detectivedroid.data.model.AppEntity
 import com.michaelcarrano.detectivedroid.presentation.model.AppMapper
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
@@ -10,13 +12,18 @@ import com.nhaarman.mockitokotlin2.whenever
 import io.reactivex.Single
 import org.junit.Before
 import org.junit.Test
+import org.mockito.Mockito
 
 class GetAppListUseCaseTest {
+
+    private val resources = mock<Resources>(defaultAnswer = Mockito.RETURNS_DEEP_STUBS) {
+        on { getString(android.R.string.unknownName) } doReturn "Unknown"
+    }
 
     private lateinit var testSubject: GetAppListUseCase
 
     private val repo = mock<AppRepository>()
-    private val mapper = AppMapper()
+    private val mapper = AppMapper(resources)
 
     @Before
     fun setUp() {
@@ -130,6 +137,37 @@ class GetAppListUseCaseTest {
         verify(repo, times(1)).getApplications()
         testObserver.assertNoErrors()
         testObserver.assertValue(mapper.mapToUiModels(allApps))
+        testObserver.dispose()
+    }
+
+    @Test
+    fun `Given apps are installed, when loadApps is called with PackageManager returning null, then return list of apps`() {
+        // GIVEN
+        val showSystemApp = false
+        val systemApps = listOf(
+            AppEntity(null, null, null, false),
+            AppEntity(null, "bar2", "baz2", false),
+            AppEntity("foo3", null, "baz3", false),
+            AppEntity("foo4", "bar4", null, false)
+        )
+
+        val userApps = listOf(
+            AppEntity(null, null, null, true),
+            AppEntity(null, "bar6", "baz6", true),
+            AppEntity("foo7", null, "baz7", true),
+            AppEntity("foo8", "bar8", null, true)
+        )
+
+        val allApps = listOf(userApps, systemApps).flatten()
+        whenever(repo.getApplications()).thenReturn(Single.just(allApps))
+
+        // WHEN
+        val testObserver = testSubject.loadApps(showSystemApp).test()
+
+        // THEN
+        verify(repo, times(1)).getApplications()
+        testObserver.assertNoErrors()
+        testObserver.assertValues(mapper.mapToUiModels(userApps))
         testObserver.dispose()
     }
 }

--- a/app/src/test/java/com/michaelcarrano/detectivedroid/presentation/model/AppMapperTest.kt
+++ b/app/src/test/java/com/michaelcarrano/detectivedroid/presentation/model/AppMapperTest.kt
@@ -1,12 +1,21 @@
 package com.michaelcarrano.detectivedroid.presentation.model
 
+import android.content.res.Resources
+import com.michaelcarrano.detectivedroid.R
 import com.michaelcarrano.detectivedroid.data.model.AppEntity
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.mockito.Mockito
 
 class AppMapperTest {
 
-    private val testSubject = AppMapper()
+    private val resources = mock<Resources>(defaultAnswer = Mockito.RETURNS_DEEP_STUBS) {
+        on { getString(android.R.string.unknownName) } doReturn "Unknown"
+    }
+
+    private val testSubject = AppMapper(resources)
 
     @Test
     fun `Given AppEntity, When mapping to AppUiModel, Then return valid AppUiModel`() {
@@ -36,5 +45,16 @@ class AppMapperTest {
             assertEquals(appEntitys[i].packageName, appUiModels[i].packageName)
             assertEquals(appEntitys[i].versionName, appUiModels[i].versionName)
         }
+    }
+
+    @Test
+    fun `Given AppEntitys with null values, When mapping to AppUiModels, then return valid AppUiModels with Unknown set as value`() {
+        val appEntity = AppEntity(null, null, null, true)
+        val appUiModel = testSubject.mapToUiModel(appEntity)
+
+        val UNKNOWN = "Unknown"
+        assertEquals(UNKNOWN, appUiModel.name)
+        assertEquals(UNKNOWN, appUiModel.packageName)
+        assertEquals(UNKNOWN, appUiModel.versionName)
     }
 }


### PR DESCRIPTION
It seems like there are cases where an app does not have a version name or version code defined, so Package Manager returns null. I did not know this is possible.

This resulted in no apps showing in the list, which made it seem like the app wasn't working.

Change logic to handle null values from PackageManager and in those cases display "Unknown" to the user.

Verified on OnePlus 8T from Amazon Device farm, there was an app on there that had this issue.

Changes come about from conversation in #45 which I am hoping these changes do resolve the issue that @alinnert brought to my attention.