### PR TITLE
Add workflow_dispatch to be able to manually trigger workflow

### DIFF
--- a/.github/workflows/libraries.yml
+++ b/.github/workflows/libraries.yml
@@ -1,6 +1,7 @@
-name: Update to latest libraries
+name: Update libraries database
 
 on:
+  workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '0 0 1 * *' # On the first day of every month


### PR DESCRIPTION
I want to be able to manually trigger this workflow when needed instead of having to wait for the cron to happen.

Also update the name of this workflow to no confuse it with updating dependencies this project uses which renovate bot should take care of once #64 is merged.