### PR TITLE
Fix fastlane :increment_version lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -21,7 +21,7 @@ platform :android do
       sh("git config --global user.name \"#{ENV["GIT_USER_NAME"]}\"")
 
       branch_name = "release-#{increment_version}"
-      puts branch_name
+      puts "Switching to branch: #{branch_name}"
 
       sh("git checkout -b #{branch_name}")
       git_commit(path: "*/libraries.json", message: "Update libraries.json with up-to-date libraries to scan.")
@@ -46,8 +46,8 @@ platform :android do
     version_name_grep = "egrep '^[[:blank:]]+versionName[[:blank:]]'  #{build_gradle_file}"
     version_code_grep = "egrep '^[[:blank:]]+versionCode[[:blank:]]'  #{build_gradle_file}"
 
-    version_name = `#{version_name_grep} | awk '{print $2}'`
-    version_code = `#{version_code_grep} | awk '{print $2}'`
+    version_name = `#{version_name_grep} | awk '{print $3}'`
+    version_code = `#{version_code_grep} | awk '{print $3}'`
 
     # Update to next patch version since this is a library update release
     version_split = version_name.split('.')
@@ -55,15 +55,15 @@ platform :android do
     version_split[2] = new_patch_version
 
     new_version_name = version_split.join('.') + "\""
-    puts new_version_name
+    puts "new version name: #{new_version_name}"
 
     new_version_code = version_code.to_i + 1
-    puts new_version_code
+    puts "new version code: #{new_version_code}"
 
     # Write next version information to file
     build_gradle = File.read("#{build_gradle_file}")
-    new_build_gradle = build_gradle.gsub("versionCode #{version_code}", "versionCode #{new_version_code}\n")
-    new_build_gradle = new_build_gradle.gsub("versionName #{version_name}", "versionName #{new_version_name}\n")
+    new_build_gradle = build_gradle.gsub("versionCode = #{version_code}", "versionCode = #{new_version_code}\n")
+    new_build_gradle = new_build_gradle.gsub("versionName = #{version_name}", "versionName = #{new_version_name}\n")
 
     File.open("#{build_gradle_file}", "w") {|file| file.puts new_build_gradle }
 


### PR DESCRIPTION
I forgot that during #65 changes where I migrated from `build.gradle` to `build.gradle.kts`, that there is now an `=` between `versionName` and the value, same for `versionCode`.

This means I need to update the print position for awk and also update the logic for rewriting the `build.gradle.kts` file with the new versions.